### PR TITLE
parse: Move consumed into Parsed wrapper struct; add fuzz infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 # Standalone workspace (not part of parent workspace)
 [workspace]
+exclude = ["fuzz"]

--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,18 @@ kani-proof name:
 kani-list:
     cargo kani list
 
+# Run a cargo-fuzz target (e.g., `just fuzz parse`, `just fuzz roundtrip -- -max_total_time=60`)
+fuzz target *ARGS:
+    cargo +nightly fuzz run {{target}} {{ARGS}}
+
+# List available fuzz targets
+fuzz-list:
+    cargo fuzz list
+
+# Generate seed corpus for the parse fuzz target
+generate-corpus:
+    cargo run --manifest-path fuzz/Cargo.toml --bin generate-corpus
+
 # Clean build artifacts
 clean:
     cargo clean

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "tar-core-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+arbitrary = { version = "1", features = ["derive"] }
+libfuzzer-sys = "0.4"
+tar = "0.4"
+
+[dependencies.tar-core]
+path = ".."
+
+[[bin]]
+name = "parse"
+path = "fuzz_targets/parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "roundtrip"
+path = "fuzz_targets/roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "differential"
+path = "fuzz_targets/differential.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "generate-corpus"
+path = "generate_corpus.rs"

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -1,0 +1,166 @@
+//! Differential fuzz target: compare tar-core against the `tar` crate.
+//!
+//! For any arbitrary byte input we parse it with both parsers and compare
+//! results. The primary invariant is that tar-core must never panic. A
+//! secondary goal is that whenever tar-rs successfully parses an entry,
+//! tar-core should produce a matching entry with equivalent metadata.
+
+#![no_main]
+
+use std::io::Cursor;
+
+use libfuzzer_sys::fuzz_target;
+use tar_core::parse::{Limits, ParseEvent, Parsed, Parser};
+use tar_core::HEADER_SIZE;
+
+/// Metadata extracted from a single tar entry, used for comparison.
+#[derive(Debug)]
+struct EntryInfo {
+    path: Vec<u8>,
+    size: u64,
+    entry_type: u8,
+    mode: u32,
+    uid: u64,
+    gid: u64,
+    mtime: u64,
+}
+
+/// Parse with the `tar` crate and collect entry metadata.
+fn parse_with_tar_rs(data: &[u8]) -> Vec<EntryInfo> {
+    let mut results = Vec::new();
+    let cursor = Cursor::new(data);
+    let mut archive = tar::Archive::new(cursor);
+
+    let entries = match archive.entries() {
+        Ok(e) => e,
+        Err(_) => return results,
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => break,
+        };
+        let header = entry.header();
+
+        let path = entry.path_bytes().into_owned();
+
+        let size = match header.size() {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let entry_type = header.entry_type().as_byte();
+        let mode = header.mode().unwrap_or(0);
+        let uid = header.uid().unwrap_or(0);
+        let gid = header.gid().unwrap_or(0);
+        let mtime = header.mtime().unwrap_or(0);
+
+        results.push(EntryInfo {
+            path,
+            size,
+            entry_type,
+            mode,
+            uid,
+            gid,
+            mtime,
+        });
+    }
+
+    results
+}
+
+/// Parse with tar-core and collect entry metadata.
+fn parse_with_tar_core(data: &[u8]) -> Vec<EntryInfo> {
+    let mut results = Vec::new();
+    let mut parser = Parser::new(Limits::permissive());
+    let mut offset = 0;
+
+    loop {
+        if offset > data.len() {
+            break;
+        }
+        let input = &data[offset..];
+
+        match parser.parse(input) {
+            Ok(Parsed {
+                event: ParseEvent::NeedData { .. },
+                ..
+            }) => break,
+            Ok(Parsed {
+                consumed,
+                event: ParseEvent::Entry(entry),
+            }) => {
+                offset += consumed;
+
+                let entry_type = entry.entry_type.to_byte();
+                results.push(EntryInfo {
+                    path: entry.path.to_vec(),
+                    size: entry.size,
+                    entry_type,
+                    mode: entry.mode,
+                    uid: entry.uid,
+                    gid: entry.gid,
+                    mtime: entry.mtime,
+                });
+
+                // Skip content + padding
+                let padded = (entry.size as usize).next_multiple_of(HEADER_SIZE);
+                if offset.saturating_add(padded) > data.len() {
+                    let _ = parser.advance_content(entry.size);
+                    break;
+                }
+                offset += padded;
+                if parser.advance_content(entry.size).is_err() {
+                    break;
+                }
+            }
+            Ok(Parsed {
+                event: ParseEvent::End,
+                ..
+            }) => break,
+            Err(_) => break,
+        }
+    }
+
+    results
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Limit input size to keep things tractable.
+    if data.len() > 256 * 1024 {
+        return;
+    }
+
+    let tar_rs_entries = parse_with_tar_rs(data);
+    let tar_core_entries = parse_with_tar_core(data);
+
+    // For each entry that tar-rs parsed successfully, check that tar-core
+    // produced a corresponding entry with matching metadata.
+    let common = tar_rs_entries.len().min(tar_core_entries.len());
+    for i in 0..common {
+        let rs = &tar_rs_entries[i];
+        let core = &tar_core_entries[i];
+
+        // Path comparison: both should agree.
+        assert_eq!(
+            rs.path,
+            core.path,
+            "path mismatch at entry {i}: tar-rs={:?} tar-core={:?}",
+            String::from_utf8_lossy(&rs.path),
+            String::from_utf8_lossy(&core.path),
+        );
+        assert_eq!(rs.size, core.size, "size mismatch at entry {i}");
+        assert_eq!(
+            rs.entry_type, core.entry_type,
+            "entry_type mismatch at entry {i}"
+        );
+        assert_eq!(rs.mode, core.mode, "mode mismatch at entry {i}");
+        assert_eq!(rs.uid, core.uid, "uid mismatch at entry {i}");
+        assert_eq!(rs.gid, core.gid, "gid mismatch at entry {i}");
+        assert_eq!(rs.mtime, core.mtime, "mtime mismatch at entry {i}");
+    }
+
+    // If tar-rs found entries that tar-core did not, that's noteworthy but
+    // not necessarily a bug (tar-rs may be more lenient in some cases).
+    // We don't panic here because edge-case differences are expected.
+});

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -1,0 +1,109 @@
+//! Fuzz target: feed arbitrary bytes into tar-core's Parser.
+//!
+//! Invariants under test:
+//! - The parser must never panic on any input (with either default or permissive limits).
+//! - Padded size is always >= size and block-aligned (or both zero).
+//! - Parsed entry paths are never empty.
+//! - Total consumed bytes never exceed the input length.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use tar_core::parse::{Limits, ParseEvent, Parsed, Parser};
+use tar_core::HEADER_SIZE;
+
+/// Drive a parser to completion over `data`, checking invariants on each entry.
+/// Returns normally on errors or NeedData — the point is that it must not panic.
+fn run_parser(data: &[u8], limits: Limits) {
+    let mut parser = Parser::new(limits);
+    let mut offset: usize = 0;
+
+    loop {
+        assert!(offset <= data.len(), "offset exceeded input length");
+        let input = &data[offset..];
+
+        match parser.parse(input) {
+            Ok(Parsed {
+                event: ParseEvent::NeedData { .. },
+                ..
+            }) => break,
+
+            Ok(Parsed {
+                consumed,
+                event: ParseEvent::Entry(entry),
+            }) => {
+                // consumed bytes must not exceed remaining input
+                assert!(
+                    consumed <= input.len(),
+                    "consumed {consumed} > remaining {}",
+                    input.len()
+                );
+
+                // Padded-size invariants:
+                // - padded_size >= size (rounding up can only increase)
+                assert!(
+                    entry.padded_size() >= entry.size,
+                    "padded_size {} < size {}",
+                    entry.padded_size(),
+                    entry.size
+                );
+                // - padded_size is block-aligned (or both are zero for empty entries)
+                if entry.size == 0 {
+                    assert_eq!(entry.padded_size(), 0, "size 0 should have padded_size 0");
+                } else {
+                    assert_eq!(
+                        entry.padded_size() % HEADER_SIZE as u64,
+                        0,
+                        "padded_size {} not block-aligned",
+                        entry.padded_size()
+                    );
+                }
+
+                // Path must not be empty
+                assert!(!entry.path.is_empty(), "entry path is empty");
+
+                offset += consumed;
+
+                // Skip content + padding; if not enough data remains, bail out.
+                let padded = entry.padded_size() as usize;
+                if offset.saturating_add(padded) > data.len() {
+                    let _ = parser.advance_content(entry.size);
+                    break;
+                }
+                offset += padded;
+                if parser.advance_content(entry.size).is_err() {
+                    break;
+                }
+            }
+
+            Ok(Parsed {
+                consumed,
+                event: ParseEvent::End,
+            }) => {
+                assert!(
+                    consumed <= input.len(),
+                    "End consumed {consumed} > remaining {}",
+                    input.len()
+                );
+                offset += consumed;
+                break;
+            }
+
+            // Parse errors are expected on fuzzed input — just stop.
+            Err(_) => break,
+        }
+    }
+
+    assert!(
+        offset <= data.len(),
+        "total consumed {offset} > input length {}",
+        data.len()
+    );
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Run with permissive limits (should accept anything that isn't structurally broken).
+    run_parser(data, Limits::permissive());
+    // Run with default limits (stricter — may error on oversized paths/pax, but must not panic).
+    run_parser(data, Limits::default());
+});

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -1,0 +1,181 @@
+//! Fuzz target: build a tar archive with EntryBuilder, parse it back, and
+//! verify roundtrip equivalence.
+//!
+//! The invariant: if EntryBuilder successfully produces an archive, Parser
+//! must parse it back to identical metadata and content.
+
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use tar_core::builder::EntryBuilder;
+use tar_core::parse::{Limits, ParseEvent, Parsed, Parser};
+use tar_core::{EntryType, HEADER_SIZE};
+
+#[derive(Debug, Arbitrary)]
+struct FuzzEntry {
+    path_bytes: Vec<u8>,
+    mode: u16,
+    uid: u16,
+    gid: u16,
+    mtime: u32,
+    uname_bytes: Vec<u8>,
+    gname_bytes: Vec<u8>,
+    content: Vec<u8>,
+    use_pax: bool,
+}
+
+/// Strip NUL bytes, ensure non-empty, clamp length.
+fn sanitize(raw: &[u8], max_len: usize) -> Option<Vec<u8>> {
+    let mut out: Vec<u8> = raw.iter().copied().filter(|&b| b != 0).collect();
+    if out.is_empty() {
+        return None;
+    }
+    out.truncate(max_len);
+    Some(out)
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let entry: FuzzEntry = match FuzzEntry::arbitrary(&mut u) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    let path = match sanitize(&entry.path_bytes, 200) {
+        Some(p) => p,
+        None => return,
+    };
+    let uname = match sanitize(&entry.uname_bytes, 64) {
+        Some(n) => n,
+        None => return,
+    };
+    let gname = match sanitize(&entry.gname_bytes, 64) {
+        Some(n) => n,
+        None => return,
+    };
+
+    let mut content = entry.content;
+    content.truncate(8192);
+    let mode = (entry.mode as u32) & 0o7777;
+    let uid = entry.uid as u64;
+    let gid = entry.gid as u64;
+    let mtime = entry.mtime as u64;
+
+    // Build the archive
+    let mut builder = if entry.use_pax {
+        EntryBuilder::new_ustar()
+    } else {
+        EntryBuilder::new_gnu()
+    };
+
+    builder.path(&path).entry_type(EntryType::Regular);
+
+    macro_rules! try_set {
+        ($expr:expr) => {
+            match $expr {
+                Ok(_) => {}
+                Err(_) => return,
+            }
+        };
+    }
+
+    try_set!(builder.mode(mode));
+    try_set!(builder.uid(uid));
+    try_set!(builder.gid(gid));
+    try_set!(builder.size(content.len() as u64));
+    try_set!(builder.mtime(mtime));
+
+    // For GNU, truncate uname/gname to 32 bytes
+    let uname_for_tar;
+    let gname_for_tar;
+    if entry.use_pax {
+        uname_for_tar = uname.clone();
+        gname_for_tar = gname.clone();
+    } else {
+        uname_for_tar = if uname.len() > 32 {
+            uname[..32].to_vec()
+        } else {
+            uname.clone()
+        };
+        gname_for_tar = if gname.len() > 32 {
+            gname[..32].to_vec()
+        } else {
+            gname.clone()
+        };
+    }
+    try_set!(builder.username(&uname_for_tar));
+    try_set!(builder.groupname(&gname_for_tar));
+
+    let header_bytes = builder.finish_bytes();
+
+    let mut archive = Vec::with_capacity(header_bytes.len() + content.len() + HEADER_SIZE * 3);
+    archive.extend_from_slice(&header_bytes);
+    archive.extend_from_slice(&content);
+    let padding = (HEADER_SIZE - (content.len() % HEADER_SIZE)) % HEADER_SIZE;
+    archive.extend(std::iter::repeat_n(0u8, padding));
+    // End-of-archive marker
+    archive.extend(std::iter::repeat_n(0u8, HEADER_SIZE * 2));
+
+    // Parse it back
+    let mut parser = Parser::new(Limits::default());
+    let mut offset = 0;
+
+    let input = &archive[offset..];
+    let parsed_entry = match parser.parse(input) {
+        Ok(Parsed {
+            consumed,
+            event: ParseEvent::Entry(entry),
+        }) => {
+            offset += consumed;
+            entry
+        }
+        other => {
+            panic!("expected Entry from archive we just built, got: {other:?}");
+        }
+    };
+
+    // Verify roundtrip
+    assert_eq!(path, parsed_entry.path.as_ref(), "path mismatch");
+    assert_eq!(mode, parsed_entry.mode, "mode mismatch");
+    assert_eq!(uid, parsed_entry.uid, "uid mismatch");
+    assert_eq!(gid, parsed_entry.gid, "gid mismatch");
+    assert_eq!(content.len() as u64, parsed_entry.size, "size mismatch");
+    assert_eq!(mtime, parsed_entry.mtime, "mtime mismatch");
+
+    if let Some(parsed_uname) = &parsed_entry.uname {
+        assert_eq!(
+            uname_for_tar.as_slice(),
+            <[u8]>::as_ref(parsed_uname),
+            "uname mismatch"
+        );
+    }
+    if let Some(parsed_gname) = &parsed_entry.gname {
+        assert_eq!(
+            gname_for_tar.as_slice(),
+            <[u8]>::as_ref(parsed_gname),
+            "gname mismatch"
+        );
+    }
+
+    // Verify content
+    let parsed_content = &archive[offset..offset + content.len()];
+    assert_eq!(content, parsed_content, "content mismatch");
+
+    // Advance past content and verify End
+    let padded = content.len().next_multiple_of(HEADER_SIZE);
+    offset += padded;
+    parser
+        .advance_content(parsed_entry.size)
+        .expect("advance_content failed");
+
+    match parser.parse(&archive[offset..]) {
+        Ok(Parsed {
+            event: ParseEvent::End,
+            ..
+        }) => {}
+        other => {
+            panic!("expected End after single entry, got: {other:?}");
+        }
+    }
+});

--- a/fuzz/generate_corpus.rs
+++ b/fuzz/generate_corpus.rs
@@ -1,0 +1,503 @@
+//! Generate seed corpus files for the `parse` fuzz target.
+//!
+//! Each seed exercises a distinct parser code path: empty archives, various
+//! entry types, GNU long name/link extensions, PAX extended headers, edge-case
+//! sizes, and multi-entry archives.
+//!
+//! Run via: `cargo run --manifest-path fuzz/Cargo.toml --bin generate-corpus`
+//! or:      `just generate-corpus`
+
+use std::fs;
+use std::path::Path;
+
+use tar_core::builder::EntryBuilder;
+use tar_core::{EntryType, HEADER_SIZE};
+
+/// End-of-archive marker: two 512-byte zero blocks.
+const EOA: [u8; 1024] = [0u8; 1024];
+
+fn main() {
+    let corpus_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("corpus/parse");
+    fs::create_dir_all(&corpus_dir).expect("create corpus dir");
+
+    let mut seeds: Vec<(&str, Vec<u8>)> = Vec::new();
+
+    // 0. Empty archive (just end-of-archive markers)
+    seeds.push(("empty", EOA.to_vec()));
+
+    // 1. Single regular file, short path, no content
+    seeds.push((
+        "regular_empty",
+        build_archive(
+            |b| {
+                b.path(b"hello.txt")
+                    .entry_type(EntryType::Regular)
+                    .mode(0o644)
+                    .unwrap()
+                    .size(0)
+                    .unwrap();
+            },
+            &[],
+        ),
+    ));
+
+    // 2. Single regular file with content
+    seeds.push((
+        "regular_content",
+        build_archive(
+            |b| {
+                b.path(b"data.bin")
+                    .entry_type(EntryType::Regular)
+                    .mode(0o755)
+                    .unwrap()
+                    .size(13)
+                    .unwrap()
+                    .uid(1000)
+                    .unwrap()
+                    .gid(1000)
+                    .unwrap()
+                    .mtime(1700000000)
+                    .unwrap();
+            },
+            b"Hello, world!",
+        ),
+    ));
+
+    // 3. GNU long name (path > 100 chars)
+    {
+        let long_path = "deep/".repeat(25) + "file.txt"; // 130 chars
+        seeds.push((
+            "gnu_long_name",
+            build_archive(
+                |b| {
+                    b.path(long_path.as_bytes())
+                        .entry_type(EntryType::Regular)
+                        .mode(0o644)
+                        .unwrap()
+                        .size(0)
+                        .unwrap();
+                },
+                &[],
+            ),
+        ));
+    }
+
+    // 4. GNU long link (symlink target > 100 chars)
+    {
+        let long_target = "/usr/share/".to_string() + &"x".repeat(100);
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"mylink")
+            .link_name(long_target.as_bytes())
+            .entry_type(EntryType::Symlink)
+            .mode(0o777)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("gnu_long_link", archive));
+    }
+
+    // 5. Symlink (short target)
+    {
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"link.txt")
+            .link_name(b"target.txt")
+            .entry_type(EntryType::Symlink)
+            .mode(0o777)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("symlink", archive));
+    }
+
+    // 6. Hardlink
+    {
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"hardlink.txt")
+            .link_name(b"original.txt")
+            .entry_type(EntryType::Link)
+            .mode(0o644)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("hardlink", archive));
+    }
+
+    // 7. Directory
+    seeds.push((
+        "directory",
+        build_archive(
+            |b| {
+                b.path(b"mydir/")
+                    .entry_type(EntryType::Directory)
+                    .mode(0o755)
+                    .unwrap()
+                    .size(0)
+                    .unwrap();
+            },
+            &[],
+        ),
+    ));
+
+    // 8. FIFO
+    seeds.push((
+        "fifo",
+        build_archive(
+            |b| {
+                b.path(b"mypipe")
+                    .entry_type(EntryType::Fifo)
+                    .mode(0o644)
+                    .unwrap()
+                    .size(0)
+                    .unwrap();
+            },
+            &[],
+        ),
+    ));
+
+    // 9. PAX extended header with long path
+    {
+        let long_path = "pax/".repeat(40) + "readme.md"; // 169 chars
+        seeds.push((
+            "pax_long_path",
+            build_archive_pax(
+                |b| {
+                    b.path(long_path.as_bytes())
+                        .entry_type(EntryType::Regular)
+                        .mode(0o644)
+                        .unwrap()
+                        .size(4)
+                        .unwrap();
+                },
+                b"test",
+            ),
+        ));
+    }
+
+    // 10. PAX with large uid/gid (overflow octal)
+    {
+        seeds.push((
+            "pax_large_ids",
+            build_archive_pax(
+                |b| {
+                    b.path(b"bigids.txt")
+                        .entry_type(EntryType::Regular)
+                        .mode(0o644)
+                        .unwrap()
+                        .size(0)
+                        .unwrap()
+                        .uid(u64::from(u32::MAX) + 1)
+                        .unwrap()
+                        .gid(u64::from(u32::MAX) + 1)
+                        .unwrap();
+                },
+                &[],
+            ),
+        ));
+    }
+
+    // 11. PAX with custom xattr
+    {
+        let mut builder = EntryBuilder::new_ustar();
+        builder
+            .path(b"xattr.txt")
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        builder.add_pax("SCHILY.xattr.user.test", b"value123");
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("pax_xattr", archive));
+    }
+
+    // 12. Multiple files in one archive
+    {
+        let mut archive = Vec::new();
+        for i in 0..5u8 {
+            let name = format!("file_{i}.txt");
+            let content = format!("content {i}");
+            let mut builder = EntryBuilder::new_gnu();
+            builder
+                .path(name.as_bytes())
+                .entry_type(EntryType::Regular)
+                .mode(0o644)
+                .unwrap()
+                .size(content.len() as u64)
+                .unwrap();
+            archive.extend_from_slice(&builder.finish_bytes());
+            archive.extend_from_slice(content.as_bytes());
+            let pad = (HEADER_SIZE - (content.len() % HEADER_SIZE)) % HEADER_SIZE;
+            archive.extend(std::iter::repeat_n(0u8, pad));
+        }
+        archive.extend_from_slice(&EOA);
+        seeds.push(("multi_file", archive));
+    }
+
+    // 13. Mixed types: dir + file + symlink
+    {
+        let mut archive = Vec::new();
+
+        // Directory
+        let mut b = EntryBuilder::new_gnu();
+        b.path(b"project/")
+            .entry_type(EntryType::Directory)
+            .mode(0o755)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        archive.extend_from_slice(&b.finish_bytes());
+
+        // Regular file with content
+        let content = b"fn main() {}";
+        let mut b = EntryBuilder::new_gnu();
+        b.path(b"project/main.rs")
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(content.len() as u64)
+            .unwrap();
+        archive.extend_from_slice(&b.finish_bytes());
+        archive.extend_from_slice(content);
+        let pad = (HEADER_SIZE - (content.len() % HEADER_SIZE)) % HEADER_SIZE;
+        archive.extend(std::iter::repeat_n(0u8, pad));
+
+        // Symlink
+        let mut b = EntryBuilder::new_gnu();
+        b.path(b"project/latest")
+            .link_name(b"main.rs")
+            .entry_type(EntryType::Symlink)
+            .mode(0o777)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        archive.extend_from_slice(&b.finish_bytes());
+
+        archive.extend_from_slice(&EOA);
+        seeds.push(("mixed_types", archive));
+    }
+
+    // 14. File with size near block boundary (exactly 512 bytes of content)
+    {
+        let content = vec![0xABu8; 512];
+        seeds.push((
+            "exact_block",
+            build_archive(
+                |b| {
+                    b.path(b"block.bin")
+                        .entry_type(EntryType::Regular)
+                        .mode(0o644)
+                        .unwrap()
+                        .size(512)
+                        .unwrap();
+                },
+                &content,
+            ),
+        ));
+    }
+
+    // 15. File with size just over block boundary (513 bytes)
+    {
+        let content = vec![0xCDu8; 513];
+        seeds.push((
+            "over_block",
+            build_archive(
+                |b| {
+                    b.path(b"overblock.bin")
+                        .entry_type(EntryType::Regular)
+                        .mode(0o644)
+                        .unwrap()
+                        .size(513)
+                        .unwrap();
+                },
+                &content,
+            ),
+        ));
+    }
+
+    // 16. Various mode values
+    seeds.push((
+        "mode_setuid",
+        build_archive(
+            |b| {
+                b.path(b"setuid.bin")
+                    .entry_type(EntryType::Regular)
+                    .mode(0o4755)
+                    .unwrap()
+                    .size(0)
+                    .unwrap();
+            },
+            &[],
+        ),
+    ));
+
+    // 17. Minimal valid header (just 512 bytes, no EOA)
+    {
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"minimal")
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        // No EOA marker — tests parser behavior on truncated input
+        seeds.push(("minimal_header", builder.finish_bytes()));
+    }
+
+    // 18. PAX with uname and gname
+    {
+        let mut builder = EntryBuilder::new_ustar();
+        builder
+            .path(b"owned.txt")
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(0)
+            .unwrap()
+            .uid(1000)
+            .unwrap()
+            .gid(1000)
+            .unwrap()
+            .username(b"testuser")
+            .unwrap()
+            .groupname(b"testgroup")
+            .unwrap();
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("uname_gname", archive));
+    }
+
+    // 19. GNU long name AND long link combined
+    {
+        let long_path = "a/".repeat(60) + "linked";
+        let long_target = "b/".repeat(60) + "target";
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(long_path.as_bytes())
+            .link_name(long_target.as_bytes())
+            .entry_type(EntryType::Symlink)
+            .mode(0o777)
+            .unwrap()
+            .size(0)
+            .unwrap();
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("gnu_long_both", archive));
+    }
+
+    // 20. Character device entry
+    {
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"dev/null")
+            .entry_type(EntryType::Char)
+            .mode(0o666)
+            .unwrap()
+            .size(0)
+            .unwrap()
+            .device(1, 3)
+            .unwrap();
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("char_device", archive));
+    }
+
+    // 21. Block device entry
+    {
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"dev/sda")
+            .entry_type(EntryType::Block)
+            .mode(0o660)
+            .unwrap()
+            .size(0)
+            .unwrap()
+            .device(8, 0)
+            .unwrap();
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(&EOA);
+        seeds.push(("block_device", archive));
+    }
+
+    // 22. PAX with multiple extensions (path + size + mtime + xattr)
+    {
+        let long_path = "multi_pax/".repeat(15) + "complex.dat";
+        let mut builder = EntryBuilder::new_ustar();
+        builder
+            .path(long_path.as_bytes())
+            .entry_type(EntryType::Regular)
+            .mode(0o600)
+            .unwrap()
+            .size(7)
+            .unwrap()
+            .mtime(9999999999)
+            .unwrap();
+        builder.add_pax(
+            "SCHILY.xattr.security.selinux",
+            b"system_u:object_r:usr_t:s0",
+        );
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend_from_slice(b"payload");
+        let pad = (HEADER_SIZE - 7) % HEADER_SIZE;
+        archive.extend(std::iter::repeat_n(0u8, pad));
+        archive.extend_from_slice(&EOA);
+        seeds.push(("pax_multi_ext", archive));
+    }
+
+    // Write seeds
+    let mut count = 0;
+    for (name, data) in &seeds {
+        let path = corpus_dir.join(name);
+        fs::write(&path, data).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+        count += 1;
+        println!("{:>4}  {:>6} bytes  {}", count, data.len(), name);
+    }
+    println!("\nGenerated {count} seed files in {}", corpus_dir.display());
+}
+
+/// Build a single-entry GNU archive with optional content.
+fn build_archive(configure: impl FnOnce(&mut EntryBuilder), content: &[u8]) -> Vec<u8> {
+    let mut builder = EntryBuilder::new_gnu();
+    configure(&mut builder);
+    assemble(builder, content)
+}
+
+/// Build a single-entry PAX/UStar archive with optional content.
+fn build_archive_pax(configure: impl FnOnce(&mut EntryBuilder), content: &[u8]) -> Vec<u8> {
+    let mut builder = EntryBuilder::new_ustar();
+    configure(&mut builder);
+    assemble(builder, content)
+}
+
+/// Assemble header + content + padding + EOA into a complete archive.
+fn assemble(mut builder: EntryBuilder, content: &[u8]) -> Vec<u8> {
+    let hdr = builder.finish_bytes();
+    let mut archive = Vec::with_capacity(hdr.len() + content.len() + HEADER_SIZE + EOA.len());
+    archive.extend_from_slice(&hdr);
+    if !content.is_empty() {
+        archive.extend_from_slice(content);
+        let pad = (HEADER_SIZE - (content.len() % HEADER_SIZE)) % HEADER_SIZE;
+        archive.extend(std::iter::repeat_n(0u8, pad));
+    }
+    archive.extend_from_slice(&EOA);
+    archive
+}


### PR DESCRIPTION
## Summary

Two changes:

1. **parse: Move consumed into Parsed wrapper struct** — Refactors the parse API so `consumed` is a field on a new `Parsed` wrapper struct rather than being embedded in individual `ParseEvent` variants. `Parser::parse()` now returns `Result<Parsed<'a>>` where `Parsed { consumed, event }`. The `ParseEvent` enum becomes `Entry(ParsedEntry)`, `End`, and `NeedData { min_bytes }` — cleaner since callers can always access `parsed.consumed` uniformly.

2. **fuzz: Add cargo-fuzz infrastructure** — Two fuzz targets (`parse` and `roundtrip`) with invariant checking, plus Justfile recipes.