### PR TITLE
fuzz: Add sparse file support to roundtrip fuzzer and corpus seeds

### DIFF
--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -10,7 +10,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use tar_core::builder::EntryBuilder;
 use tar_core::parse::{Limits, ParseEvent, Parser};
-use tar_core::{EntryType, HEADER_SIZE};
+use tar_core::{EntryType, SparseEntry, HEADER_SIZE};
 
 #[derive(Debug, Arbitrary)]
 struct FuzzEntry {
@@ -26,6 +26,10 @@ struct FuzzEntry {
     /// Selects entry type: 0=Regular, 1=Directory, 2=Symlink, 3=Hardlink
     entry_kind: u8,
     link_target_bytes: Vec<u8>,
+    /// (gap, length) pairs to build a sparse map
+    sparse_entries: Vec<(u16, u16)>,
+    /// When true and entry_kind selects Regular, build a sparse entry
+    use_sparse: bool,
 }
 
 /// Strip NUL bytes, ensure non-empty, clamp length.
@@ -64,6 +68,27 @@ fuzz_target!(|data: &[u8]| {
     let uid = entry.uid as u64;
     let gid = entry.gid as u64;
     let mtime = entry.mtime as u64;
+
+    // Build sparse map if applicable
+    let is_sparse = entry.use_sparse && entry.entry_kind % 4 == 0;
+    let sparse_map: Vec<SparseEntry> = if is_sparse {
+        let mut map = Vec::new();
+        let mut cursor = 0u64;
+        for &(gap, length) in entry.sparse_entries.iter().take(50) {
+            if length == 0 {
+                continue;
+            }
+            let offset = cursor.saturating_add(gap as u64);
+            map.push(SparseEntry {
+                offset,
+                length: length as u64,
+            });
+            cursor = offset.saturating_add(length as u64);
+        }
+        map
+    } else {
+        Vec::new()
+    };
 
     // Pick entry type and adjust content/link accordingly
     let (entry_type, link_target) = match entry.entry_kind % 4 {
@@ -111,10 +136,29 @@ fuzz_target!(|data: &[u8]| {
         };
     }
 
+    // For sparse entries, the on-disk size is the sum of sparse chunk lengths
+    // and content is just zero-filled padding.
+    let on_disk_size: u64;
+    let real_size: u64;
+    if is_sparse && !sparse_map.is_empty() {
+        on_disk_size = sparse_map.iter().map(|e| e.length).sum();
+        real_size = sparse_map.last().map(|e| e.offset + e.length).unwrap_or(0);
+        content = vec![0u8; on_disk_size as usize];
+        builder.sparse(&sparse_map, real_size);
+    } else if is_sparse {
+        // Empty sparse map: treat as empty regular file
+        on_disk_size = 0;
+        real_size = 0;
+        content.clear();
+    } else {
+        on_disk_size = content.len() as u64;
+        real_size = 0; // unused for non-sparse
+    }
+
     try_set!(builder.mode(mode));
     try_set!(builder.uid(uid));
     try_set!(builder.gid(gid));
-    try_set!(builder.size(content.len() as u64));
+    try_set!(builder.size(on_disk_size));
     try_set!(builder.mtime(mtime));
 
     // For GNU, truncate uname/gname to 32 bytes
@@ -153,23 +197,63 @@ fuzz_target!(|data: &[u8]| {
     let mut offset = 0;
 
     let input = &archive[offset..];
-    let parsed_entry = match parser.parse(input) {
-        Ok(ParseEvent::Entry { consumed, entry }) => {
+    let event = match parser.parse(input) {
+        Ok(e) => e,
+        other => {
+            panic!("expected successful parse from archive we just built, got: {other:?}");
+        }
+    };
+
+    // Extract parsed entry and verify sparse-specific fields
+    let parsed_entry = match event {
+        ParseEvent::Entry { consumed, entry } => {
+            assert!(
+                !is_sparse || sparse_map.is_empty(),
+                "expected SparseEntry for non-empty sparse, got Entry"
+            );
+            offset += consumed;
+            entry
+        }
+        ParseEvent::SparseEntry {
+            consumed,
+            entry,
+            sparse_map: parsed_sparse_map,
+            real_size: parsed_real_size,
+        } => {
+            assert!(
+                is_sparse && !sparse_map.is_empty(),
+                "expected Entry for non-sparse, got SparseEntry"
+            );
+            assert_eq!(
+                sparse_map.len(),
+                parsed_sparse_map.len(),
+                "sparse_map length mismatch"
+            );
+            for (i, expected) in sparse_map.iter().enumerate() {
+                assert_eq!(*expected, parsed_sparse_map[i], "sparse_map[{i}] mismatch");
+            }
+            assert_eq!(real_size, parsed_real_size, "real_size mismatch");
             offset += consumed;
             entry
         }
         other => {
-            panic!("expected Entry from archive we just built, got: {other:?}");
+            panic!("expected Entry or SparseEntry from archive we just built, got: {other:?}");
         }
     };
 
     // Verify roundtrip
     assert_eq!(path, parsed_entry.path.as_ref(), "path mismatch");
-    assert_eq!(entry_type, parsed_entry.entry_type, "entry_type mismatch");
+    if is_sparse && !sparse_map.is_empty() {
+        // Sparse entries have GnuSparse type in GNU mode; in PAX mode
+        // the parser may report Regular. Just check on-disk size.
+        assert_eq!(on_disk_size, parsed_entry.size, "on-disk size mismatch");
+    } else {
+        assert_eq!(entry_type, parsed_entry.entry_type, "entry_type mismatch");
+        assert_eq!(content.len() as u64, parsed_entry.size, "size mismatch");
+    }
     assert_eq!(mode, parsed_entry.mode, "mode mismatch");
     assert_eq!(uid, parsed_entry.uid, "uid mismatch");
     assert_eq!(gid, parsed_entry.gid, "gid mismatch");
-    assert_eq!(content.len() as u64, parsed_entry.size, "size mismatch");
     assert_eq!(mtime, parsed_entry.mtime, "mtime mismatch");
 
     // Verify link target for symlinks/hardlinks
@@ -200,8 +284,8 @@ fuzz_target!(|data: &[u8]| {
         );
     }
 
-    // Verify content (only for regular files)
-    if !content.is_empty() {
+    // Verify content (only for non-sparse regular files)
+    if !is_sparse && !content.is_empty() {
         let parsed_content = &archive[offset..offset + content.len()];
         assert_eq!(content, parsed_content, "content mismatch");
     }

--- a/fuzz/generate_corpus.rs
+++ b/fuzz/generate_corpus.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::path::Path;
 
 use tar_core::builder::EntryBuilder;
-use tar_core::{EntryType, HEADER_SIZE};
+use tar_core::{EntryType, SparseEntry, HEADER_SIZE};
 
 /// End-of-archive marker: two 512-byte zero blocks.
 const EOA: [u8; 1024] = [0u8; 1024];
@@ -567,6 +567,203 @@ fn main() {
         let mut archive = raw.to_vec();
         archive.extend_from_slice(&EOA);
         seeds.push(("v7_format", archive));
+    }
+
+    // 28. GNU sparse, 2 inline entries
+    {
+        let sparse_map = [
+            SparseEntry {
+                offset: 0,
+                length: 100,
+            },
+            SparseEntry {
+                offset: 1000,
+                length: 200,
+            },
+        ];
+        let on_disk: u64 = 300;
+        let real_size: u64 = 1200;
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"sparse_gnu_basic.bin")
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(on_disk)
+            .unwrap()
+            .sparse(&sparse_map, real_size);
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend(vec![0u8; on_disk.next_multiple_of(512) as usize]);
+        archive.extend_from_slice(&EOA);
+        seeds.push(("sparse_gnu_basic", archive));
+    }
+
+    // 29. GNU sparse, 6 entries (needs extension block: >4 inline descriptors)
+    {
+        let sparse_map: Vec<SparseEntry> = (0..6)
+            .map(|i| SparseEntry {
+                offset: i * 1000,
+                length: 50,
+            })
+            .collect();
+        let on_disk: u64 = 300;
+        let real_size: u64 = 5050;
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"sparse_gnu_ext.bin")
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(on_disk)
+            .unwrap()
+            .sparse(&sparse_map, real_size);
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend(vec![0u8; on_disk.next_multiple_of(512) as usize]);
+        archive.extend_from_slice(&EOA);
+        seeds.push(("sparse_gnu_ext", archive));
+    }
+
+    // 30. GNU sparse, 28 entries (multiple extension blocks: 4 inline + 21 + 3)
+    {
+        let sparse_map: Vec<SparseEntry> = (0..28)
+            .map(|i| SparseEntry {
+                offset: i * 500,
+                length: 30,
+            })
+            .collect();
+        let on_disk: u64 = 28 * 30;
+        let real_size: u64 = 27 * 500 + 30;
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(b"sparse_gnu_multi_ext.bin")
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(on_disk)
+            .unwrap()
+            .sparse(&sparse_map, real_size);
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend(vec![0u8; on_disk.next_multiple_of(512) as usize]);
+        archive.extend_from_slice(&EOA);
+        seeds.push(("sparse_gnu_multi_ext", archive));
+    }
+
+    // 31. PAX sparse v1.0, 2 entries
+    {
+        let sparse_map = [
+            SparseEntry {
+                offset: 0,
+                length: 100,
+            },
+            SparseEntry {
+                offset: 3000,
+                length: 400,
+            },
+        ];
+        let on_disk: u64 = 500;
+        let real_size: u64 = 3400;
+        let mut builder = EntryBuilder::new_ustar();
+        builder
+            .path(b"sparse_pax_basic.dat")
+            .mode(0o644)
+            .unwrap()
+            .size(on_disk)
+            .unwrap()
+            .sparse(&sparse_map, real_size);
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend(vec![0u8; on_disk.next_multiple_of(512) as usize]);
+        archive.extend_from_slice(&EOA);
+        seeds.push(("sparse_pax_basic", archive));
+    }
+
+    // 32. PAX sparse v1.0, 10 entries
+    {
+        let sparse_map: Vec<SparseEntry> = (0..10)
+            .map(|i| SparseEntry {
+                offset: i * 1000,
+                length: 50,
+            })
+            .collect();
+        let on_disk: u64 = 500;
+        let real_size: u64 = 9050;
+        let mut builder = EntryBuilder::new_ustar();
+        builder
+            .path(b"sparse_pax_many.dat")
+            .mode(0o644)
+            .unwrap()
+            .size(on_disk)
+            .unwrap()
+            .sparse(&sparse_map, real_size);
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend(vec![0u8; on_disk.next_multiple_of(512) as usize]);
+        archive.extend_from_slice(&EOA);
+        seeds.push(("sparse_pax_many", archive));
+    }
+
+    // 33. GNU sparse with long path (>100 bytes)
+    {
+        let long_path = "sparse/".repeat(20) + "data.bin"; // 148 chars
+        let sparse_map = [
+            SparseEntry {
+                offset: 0,
+                length: 200,
+            },
+            SparseEntry {
+                offset: 4096,
+                length: 100,
+            },
+        ];
+        let on_disk: u64 = 300;
+        let real_size: u64 = 4196;
+        let mut builder = EntryBuilder::new_gnu();
+        builder
+            .path(long_path.as_bytes())
+            .entry_type(EntryType::Regular)
+            .mode(0o644)
+            .unwrap()
+            .size(on_disk)
+            .unwrap()
+            .sparse(&sparse_map, real_size);
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend(vec![0u8; on_disk.next_multiple_of(512) as usize]);
+        archive.extend_from_slice(&EOA);
+        seeds.push(("sparse_gnu_longpath", archive));
+    }
+
+    // 34. PAX sparse with long path (>100 bytes)
+    {
+        let long_path = "paxsparse/".repeat(15) + "file.dat"; // 158 chars
+        let sparse_map = [
+            SparseEntry {
+                offset: 0,
+                length: 512,
+            },
+            SparseEntry {
+                offset: 8192,
+                length: 256,
+            },
+        ];
+        let on_disk: u64 = 768;
+        let real_size: u64 = 8448;
+        let mut builder = EntryBuilder::new_ustar();
+        builder
+            .path(long_path.as_bytes())
+            .mode(0o644)
+            .unwrap()
+            .size(on_disk)
+            .unwrap()
+            .sparse(&sparse_map, real_size);
+        let hdr = builder.finish_bytes();
+        let mut archive = hdr;
+        archive.extend(vec![0u8; on_disk.next_multiple_of(512) as usize]);
+        archive.extend_from_slice(&EOA);
+        seeds.push(("sparse_pax_longpath", archive));
     }
 
     // Write seeds


### PR DESCRIPTION
## Summary\n\n- Extend the roundtrip fuzz target to exercise sparse file building and parsing, fixing the previous panic on `SparseEntry` events\n- Add `sparse_entries` and `use_sparse` fields to `FuzzEntry` so libfuzzer can generate sparse archives with valid non-overlapping maps\n- Add 7 sparse seed archives to `generate_corpus.rs` covering GNU inline/extension/multi-extension formats, PAX v1.0, and long paths for both formats\n\n## Details\n\nThe roundtrip fuzzer previously panicked at line 161 when the parser emitted a `SparseEntry` event. Now it handles both `Entry` and `SparseEntry`, verifying sparse map contents, real_size, on-disk size, path, and metadata roundtrip correctly.\n\nNew corpus seeds:\n- `sparse_gnu_basic` — 2 inline entries\n- `sparse_gnu_ext` — 6 entries (1 extension block)\n- `sparse_gnu_multi_ext` — 28 entries (multiple extension blocks)\n- `sparse_pax_basic` — PAX v1.0 with 2 entries\n- `sparse_pax_many` — PAX v1.0 with 10 entries\n- `sparse_gnu_longpath` — GNU sparse with >100 byte path\n- `sparse_pax_longpath` — PAX sparse with >100 byte path"