### PR TITLE
ci: Enable merge queue support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 env:
   CARGO_NET_RETRY: 10
@@ -109,3 +110,21 @@ jobs:
           path: |
             fuzz/artifacts/
             target/fuzz-logs/
+
+  # Sentinel job for required checks - configure this job name in repository settings.
+  # Accepts 'skipped' as success so that merge_group-only jobs don't block PRs.
+  required-checks:
+    if: always()
+    needs: [build-test, msrv, fuzz]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          FAILED=$(echo "$NEEDS" | jq -r 'to_entries[] | select(.value.result | IN("success","skipped") | not) | .key')
+          if [ -n "$FAILED" ]; then
+            echo "The following jobs did not succeed: $FAILED"
+            exit 1
+          fi
+          echo "All jobs succeeded or were skipped."


### PR DESCRIPTION
Add the `merge_group` event trigger so CI runs when a pull request enters the GitHub merge queue. Also add a `required-checks` sentinel job that gates on all other jobs — this is the single status check name to configure in repository branch protection settings.

xref: https://github.com/bootc-dev/infra/issues/143